### PR TITLE
Add setup-tektoncd action

### DIFF
--- a/.github/workflows/use-setup-tektoncd-action.yaml
+++ b/.github/workflows/use-setup-tektoncd-action.yaml
@@ -1,0 +1,45 @@
+---
+name: use-setup-tektoncd-action
+
+permissions:
+  contents: read
+
+on:
+  push:
+    tags-ignore:
+      - '**'
+    branches:
+      - '**'
+    paths-ignore:
+      - '*.md'
+  pull_request:
+    branches:
+      - '**'
+    paths-ignore:
+      - '*.md'
+
+jobs:
+  use-action:
+    runs-on: ubuntu-latest
+    steps:
+      # preparing the Kubernetes cluster# (KinD) and installing kubectl
+      - uses: helm/kind-action@v1.5.0
+        with:
+          cluster_name: kind
+          wait: 120s
+
+      # checking out the project code on the current workspace
+      - uses: actions/checkout@v3
+
+      # self loading the action.yaml definitions, making possible to run the action defined on this
+      # project directly
+      - uses: ./setup-tektoncd/
+        with:
+          pipeline_version: latest
+          feature_flags: '{ "enable-custom-tasks": "true" }'
+          cli_version: latest
+
+      # assert the changes performed by this action
+      - shell: bash
+        run: |
+          ./assert.sh

--- a/.github/workflows/use-setup-tektoncd-cli-action.yaml
+++ b/.github/workflows/use-setup-tektoncd-cli-action.yaml
@@ -1,0 +1,34 @@
+---
+name: use-action
+
+on:
+  push:
+    tags-ignore:
+      - '**'
+    branches:
+      - '**'
+    paths-ignore:
+      - '*.md'
+  pull_request:
+    branches:
+      - '**'
+    paths-ignore:
+      - '*.md'
+
+jobs:
+  use-action:
+    runs-on: ubuntu-latest
+    steps:
+      # checking out the project code on the current workspace
+      - uses: actions/checkout@v3
+
+      # self loading the action.yaml definitions, making possible to run the action defined on this
+      # project directly
+      - uses: ./setup-tektoncd-cli/
+        with:
+          version: latest
+
+      # assert the changes performed by this action
+      - shell: bash
+        run: |
+          ./assert.sh

--- a/OWNERS
+++ b/OWNERS
@@ -3,8 +3,6 @@
 approvers:
 - vdemeester
 - afrittoli
-- otaviof
 reviewers:
 - vdemeester
 - afrittoli
-- otaviof

--- a/README.md
+++ b/README.md
@@ -1,3 +1,51 @@
 # *Official* Tekton GitHub actions
 
 This repository holds *official* GitHub actions to be used in your GitHub Workflows.
+
+## `setup-tektoncd`
+
+Action to rollout [Tekton Pipeline][githubTektonPipeline], [CLI (`tkn`)][githubTektonCLI] and a [Container-Registry][containerRegistry] instance, setting up the environment for testing using these components.
+
+Example usage below with inputs using default values:
+
+```yaml
+---
+jobs:
+  setup-tektoncd:
+    steps:
+      # using KinD to provide the Kubernetes instance and kubectl
+      - uses: helm/kind-action@v1.5.0
+        with:
+          cluster_name: kind
+
+      # setting up Tekton Pipelines, CLI and additional components...
+      - uses: tektoncd/actions/setup-tektoncd@main
+        with:
+          pipeline_version: latest
+          setup_registry: "true"
+          patch_etc_hosts: "true"
+```
+
+See more on [`setup-tektoncd/README.md`](./setup-tektoncd).
+
+## `setup-tektoncd-cli`
+
+Action to install the [Tekton CLI (`tkn`)][githubTektonCLI].
+
+Example usage below with inputs using some default values:
+
+```yaml
+---
+jobs:
+  setup-tektoncd-cli:
+    steps:
+      - uses: tektoncd/actions/setup-tektoncd-cli@main
+        with:
+          version: latest
+```
+
+By default the action is set to install `latest` release, use the `version` input for a specific target.
+
+[containerRegistry]: https://docs.docker.com/registry/spec/api/
+[githubTektonPipeline]: https://github.com/tektoncd/pipeline
+[githubTektonCLI]: https://github.com/tektoncd/cli

--- a/setup-tektoncd-cli/LICENSE
+++ b/setup-tektoncd-cli/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/setup-tektoncd-cli/README.md
+++ b/setup-tektoncd-cli/README.md
@@ -1,0 +1,24 @@
+[![use-action][useActionWorkflowBadge]][useActionWorkflow]
+
+`setup-tektoncd-cli`
+------------------
+
+GitHub Action to install [Tekton CLI (`tkn`)][githubTektonCLI].
+
+# Usage
+
+```yaml
+---
+jobs:
+  setup-tektoncd-cli:
+    steps:
+      - uses: tektoncd/actions/setup-tektoncd-cli@main
+        with:
+          version: latest
+```
+
+By default the action is set to install `latest` release, use the `version` input for a specific target.
+
+[githubTektonCLI]: https://github.com/tektoncd/cli
+[useActionWorkflowBadge]: https://github.com/tektoncd/actions/setup-tektoncd-cli/actions/workflows/use-action.yaml/badge.svg
+[useActionWorkflow]: https://github.com/tektoncd/actions/setup-tektoncd-cli/actions/workflows/use-action.yaml

--- a/setup-tektoncd-cli/action.yaml
+++ b/setup-tektoncd-cli/action.yaml
@@ -1,0 +1,25 @@
+---
+name: setup-tektoncd-cli
+description: |
+  Installs the Tekton CLI (tkn)
+branding:
+  color: blue
+  icon: anchor
+inputs:
+  version:
+    description: |
+      Tekton CLI release version
+    default: latest
+    required: false
+runs:
+  using: composite
+  steps:
+    # pre-flight checks, making sure the dependencies are met
+    - shell: bash
+      run: ${{ github.action_path }}/probe.sh
+
+    # installs the pre-compiled Tekton CLI
+    - shell: bash
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+      run: sudo --preserve-env ${{ github.action_path }}/install-cli.sh

--- a/setup-tektoncd-cli/assert.sh
+++ b/setup-tektoncd-cli/assert.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Assert the changes made by this action.
+#
+
+shopt -s inherit_errexit
+set -eu -o pipefail
+
+source "$(dirname ${BASH_SOURCE[0]})/common.sh"
+
+phase "Asserting the CLI (tkn) is installed"
+probe_bin_on_path "tkn"

--- a/setup-tektoncd-cli/common.sh
+++ b/setup-tektoncd-cli/common.sh
@@ -1,0 +1,66 @@
+#
+# Helper Functions
+#
+
+# print error message and exit on error.
+function fail() {
+    echo "ERROR: ${*}" >&2
+    exit 1
+}
+
+# print out a strutured message.
+function phase() {
+    echo "---> Phase: ${*}..."
+}
+
+# inspect the path after the informed executable name.
+function probe_bin_on_path() {
+    local name="${1}"
+
+    if ! type -a ${name} >/dev/null 2>&1; then
+        fail "Can't find '${name}' on 'PATH=${PATH}'"
+    fi
+}
+
+# get the artifact url for the specific version (release) or latest.
+function get_release_artifact_url() {
+    local _org_repo="${1}"
+    local _version="${2}"
+
+    local _url="https://api.github.com/repos/${_org_repo}/releases"
+    if [[ "${_version}" == "latest" ]]; then
+        echo $(
+            curl -s ${_url}/latest |
+                jq -r '.assets[].browser_download_url' |
+                egrep -i 'linux_(x86_64|amd64)' |
+                head -n 1
+        )
+    else
+        echo $(
+            curl -s ${_url} |
+                jq -r ".[] | select(.tag_name == \"${_version}\") | .assets[].browser_download_url" |
+                egrep -i 'linux_(x86_64|amd64)' |
+                head -n 1
+        )
+    fi
+}
+
+# given the download url and excutable name, download and extract the executable from the artifact
+# tarball on the `/usr/local/bin` (prefix).
+function download_and_install() {
+    local _url="${1}"
+    local _bin_name="${2}"
+
+    local _tarball="$(basename ${_url})"
+    local _tmp_tarball="/tmp/${_tarball}"
+    local _prefix="/usr/local/bin"
+
+    [[ -f "${_tmp_tarball}" ]] && rm -f "${_tmp_tarball}"
+
+    phase "Downloading '${_url}' to '${_tmp_tarball}'"
+    curl -sL ${_url} >${_tmp_tarball}
+
+    phase "Installing '${_bin_name}' on prefix '${_prefix}'"
+    tar -C ${_prefix} -zxvpf ${_tmp_tarball} ${_bin_name}
+    rm -fv "${_tmp_tarball}"
+}

--- a/setup-tektoncd-cli/install-cli.sh
+++ b/setup-tektoncd-cli/install-cli.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Download and install the informed tkn version, using "/usr/local/bin" as PREFIX.
+#
+
+shopt -s inherit_errexit
+set -eu -o pipefail
+
+source "$(dirname ${BASH_SOURCE[0]})/common.sh"
+
+phase "Inspecting enviroment variables"
+
+readonly INPUT_VERSION="${INPUT_VERSION:-}"
+
+[[ -z "${INPUT_VERSION}" ]] &&
+    fail "INPUT_VERSION environment variable is not set!"
+
+phase "Searching for '${INPUT_VERSION}' release artifact"
+
+readonly url=$(get_release_artifact_url "tektoncd/cli" ${INPUT_VERSION})
+
+[[ -z "${url}" ]] &&
+    fail "Unable to acrquire the release artifact download URL"
+
+phase "Download URL '${url}'"
+download_and_install ${url} "tkn"

--- a/setup-tektoncd-cli/probe.sh
+++ b/setup-tektoncd-cli/probe.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Inspect the instance to make sure the dependencies needed are in place.
+#
+
+shopt -s inherit_errexit
+set -eu -o pipefail
+
+source "$(dirname ${BASH_SOURCE[0]})/common.sh"
+
+probe_bin_on_path "curl"
+probe_bin_on_path "jq"
+probe_bin_on_path "tar"

--- a/setup-tektoncd/.gitignore
+++ b/setup-tektoncd/.gitignore
@@ -1,0 +1,2 @@
+/.env
+/.vscode/

--- a/setup-tektoncd/README.md
+++ b/setup-tektoncd/README.md
@@ -1,0 +1,122 @@
+[![use-action][useActionWorkflowBadge]][useActionWorkflow]
+
+`setup-tektoncd`
+----------------
+
+Action to rollout [Tekton Pipeline][githubTektonPipeline], [CLI (`tkn`)][githubTektonCLI] and a [Container-Registry][containerRegistry] instance, setting up the environment for testing using these components.
+
+# GitHub Action Usage
+
+Example usage below with inputs using default values:
+
+```yaml
+---
+jobs:
+  setup-tektoncd:
+    steps:
+      # using KinD to provide the Kubernetes instance and kubectl
+      - uses: helm/kind-action@v1.5.0
+        with:
+          cluster_name: kind
+
+      # setting up Tekton Pipelines, CLI and additional components...
+      - uses: tektoncd/actions/setup-tektoncd@main
+        with:
+          pipeline_version: latest
+          feature_flags: '{}'
+          cli_version: latest
+          setup_registry: "true"
+          patch_etc_hosts: "true"
+```
+
+The action uses the current Kubernetes instance available ([KinD][sigsKinD] for example), thus requires `kubectl` on the `${PATH}`.
+
+## Inputs
+
+| Input               | Required | Description                                     |
+|:--------------------|:--------:|:------------------------------------------------|
+| `pipeline_version`  | `false`  | Tekton Pipeline version                         |
+| `feature_flags`     | `false`  | Tekton Pipeline feature flags (JSON) payload    |
+| `cli_version`       | `false`  | Tekton CLI (tkn) version                        |
+| `setup_registry`    | `false`  | Rollout a Container-Registry (v2)               |
+| `patch_etc_hosts`   | `false`  | Add Container-Registry hostname to `/etc/hosts` |
+
+# Components
+
+## Tekton Pipelines
+
+[Tekton Pipelines][githubTektonPipeline] is deployed on the namespace `tekton-pipelines` and the involved deployments are followed until completion, so the setup process waits until the instances are available and in case of error the workflow is interrupted.
+
+### Feature-Flags
+
+Tekton Pipelines exposes [feature-flags][githubTektonFeatureFlags] using a `ConfigMap` named `feature-flags`. These flags can be set using the input `feature_flags`, a JSON formated string containing the respective flags and values. For example:
+
+```yaml
+---
+jobs:
+  setup-tektoncd:
+    steps:
+      - uses: tektoncd/actions/setup-tektoncd@main
+        with:
+          feature_flags: '{ "enable-custom-tasks": "true" }'
+```
+
+The result is observed on the following example:
+
+```
+$ kubectl --namespace=tekton-pipelines get configmap feature-flags --output=json |jq '.data'
+{
+  // ...
+  "enable-custom-tasks": "true",
+  // ...
+}
+```
+
+## CLI (`tkn`)
+
+[Tekton CLI][githubTektonCLI] is installed on `/usr/local/bin` directory and uses the same Kubernetes context than `kubectl`.
+
+## Container-Registry
+
+A [Container-Registry][containerRegistry] instance is deployed on the `registry` namespace using the same rollout approach than Tekton Pipelines.
+
+The registry is available on port `32222` and uses the Kubernetes internal service hostname, `registry.registry.svc.cluster.local`, which means the fully qualified container images (plus tag) will look like the example below:
+
+```text
+registry.registry.svc.cluster.local:32222/namespace/project:tag
+```
+
+The registry does not require authentication, uses HTTP protocol, is available outside of the Kubernetes instance as well. The Action Input `patch_etc_hosts` makes the registry hostname resolve to `127.0.0.1` and the service exposes the port `32222` as a `hostPort` too.
+
+# Scripts
+
+Alternatively, you can run the scripts directly to rollout Tekton Pipelines and the other components, the recommended approach is using a `.env` file with the required [inputs](./inputs.sh).
+
+```bash
+cat >.env <<EOS
+export INPUT_PIPELINE_VERSION="latest"
+export INPUT_CLI_VERSION="latest"
+export INPUT_FEATURE_FLAGS='{ "enable-custom-tasks": "true" }'
+EOS
+```
+
+There are shell plugins to automatically load the `.env` file, once the required environment variables are set you can invoke each script individually:
+
+```bash
+source .env
+
+./install-pipeline.sh
+./install-registry.sh
+
+sudo ./install-cli.sh
+```
+
+The script name reflects the component deployed and they are idempotent, you can run them more than once without side effects.
+
+[containerRegistry]: https://docs.docker.com/registry/spec/api/
+[githubTektonCLI]: https://github.com/tektoncd/cli
+[githubTektonFeatureFlags]: https://github.com/tektoncd/pipeline/blob/main/config/config-feature-flags.yaml
+[githubTektonPipeline]: https://github.com/tektoncd/pipeline
+[sigsKinD]: https://kind.sigs.k8s.io
+[useActionWorkflow]: https://github.com/tektoncd/actions/setup-tektoncd/actions/workflows/use-action.yaml
+[useActionWorkflowBadge]: https://github.com/tektoncd/actions/setup-tektoncd/actions/workflows/use-action.yaml/badge.svg

--- a/setup-tektoncd/action.yaml
+++ b/setup-tektoncd/action.yaml
@@ -1,0 +1,74 @@
+---
+name: Tekton Pipeline Setup (CI)
+description: |
+  Installs Tekton Pipelines on the informed Kubernetes KinD instance, includes a local Container
+  Registry and the `tkn` cli.
+branding:
+  color: blue
+  icon: anchor
+inputs:
+  pipeline_version:
+    description: |
+      Tekton Pipeline release version
+    required: false
+    default: v0.45.0
+  feature_flags:
+    description: |
+      JSON payload for the Tekton Pipelines feature-flags, a configmap containing features toggles.
+      For instance '{ "enable-api-fields": "alpha" }'
+    required: false
+    default: '{}'
+  cli_version:
+    description: |
+      Tekton CLI (tkn) version
+    required: false
+    default: latest
+  setup_registry:
+    description: |
+      When enabled, the action deploys a Container Registry instance
+    required: false
+    default: "true"
+  patch_etc_hosts:
+    description: |
+      Patch "/etc/hosts" to alias the Container Registry hostname to "127.0.0.1"
+    required: false
+    default: "true"
+runs:
+  using: composite
+  steps:
+    # pre-flight checks, making sure the dependencies needed for the upcoming steps are available
+    - shell: bash
+      run: ${{ github.action_path }}/probe.sh
+
+    # deploying the container registry when input flag is set, waiting for the deployment to reach
+    # ready status before proceeding
+    - shell: bash
+      if: ${{ inputs.setup_registry == 'true' }}
+      working-directory: ${{ github.action_path }}
+      env:
+        INPUT_PIPELINE_VERSION: ${{ inputs.pipeline_version }}
+        INPUT_FEATURE_FLAGS: ${{ inputs.feature_flags }}
+        INPUT_CLI_VERSION: ${{ inputs.cli_version }}
+      run: ${{ github.action_path }}/install-registry.sh
+
+    # deploying tekton pipline controller and dependencies, waiting for it to reach ready status
+    - shell: bash
+      env:
+        INPUT_PIPELINE_VERSION: ${{ inputs.pipeline_version }}
+        INPUT_FEATURE_FLAGS: ${{ inputs.feature_flags }}
+        INPUT_CLI_VERSION: ${{ inputs.cli_version }}
+      run: ${{ github.action_path }}/install-pipeline.sh
+
+    # patches the /etc/hosts to include the container registry hostname resolving to 127.0.0.1
+    - shell: bash
+      if: ${{ inputs.patch_etc_hosts == 'true' }}
+      env:
+        INPUT_PIPELINE_VERSION: ${{ inputs.pipeline_version }}
+        INPUT_FEATURE_FLAGS: ${{ inputs.feature_flags }}
+        INPUT_CLI_VERSION: ${{ inputs.cli_version }}
+      run: sudo --preserve-env ${{ github.action_path }}/patch-etc-hosts.sh
+
+    # installs the pre-compiled Tekton CLI
+    - uses: tektoncd/actions/setup-tektoncd-cli@main
+      with:
+        version: ${{ inputs.cli_version }}

--- a/setup-tektoncd/assert.sh
+++ b/setup-tektoncd/assert.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Assert the changes made by this action.
+#
+
+shopt -s inherit_errexit
+set -eu -o pipefail
+
+source common.sh
+
+phase "Asserting the Container Registry rollout status"
+rollout_status "${REGISTRY_NAMESPACE}" "registry"
+
+phase "Asserting the /etc/hosts have been patched"
+if ! grep -E -q '127.0.0.1.*registry' /etc/hosts; then
+	fail "/etc/hosts does not include the registry hostname"
+fi
+
+phase "Asserting the Tekton Pipeline Controller"
+rollout_status "${TEKTON_NAMESPACE}" "tekton-pipelines-controller"
+
+phase "Asserting the Tekton Pipeline WebHook"
+rollout_status "${TEKTON_NAMESPACE}" "tekton-pipelines-webhook"
+
+phase "Asserting the feature-flag 'enable-custom-tasks' is 'true'"
+if ! (
+	kubectl get configmap feature-flags \
+		--namespace=${TEKTON_NAMESPACE} \
+		--output=json \
+		|grep -E 'enable-custom-tasks.*"true",'
+); then
+	fail "Feature-flag 'enable-custom-tasks' is not enabled ('true')!"
+fi
+
+phase "Asserting the CLI (tkn) is installed"
+probe_bin_on_path "tkn"

--- a/setup-tektoncd/common.sh
+++ b/setup-tektoncd/common.sh
@@ -1,0 +1,73 @@
+#
+# Environment Variables with Default Values
+#
+
+# namespace name for the container registry
+readonly REGISTRY_NAMESPACE="${REGISTRY_NAMESPACE:-registry}"
+export REGISTRY_NAMESPACE
+# the container registry uses the internal k8s service hosntame
+readonly REGISTRY_HOSTNAME="${REGISTRY_HOSTNAME:-registry.registry.svc.cluster.local}"
+export REGISTRY_HOSTAME
+# namespace name for Tekton Pipeline controller
+readonly TEKTON_NAMESPACE="${TEKTON_NAMESPACE:-tekton-pipelines}"
+export TEKTON_NAMESPACE
+# timeout employed during rollout status and deployments in general
+readonly DEPLOYMENT_TIMEOUT="${DEPLOYMENT_TIMEOUT:-5m}"
+export DEPLOYMENT_TIMEOUT
+#
+# Helper Functions
+#
+
+# print error message and exit on error.
+function fail() {
+    echo "ERROR: ${*}" >&2
+    exit 1
+}
+
+# print out a strutured message.
+function phase() {
+    echo "---> Phase: ${*}..."
+}
+
+# uses kubectl to check the deployment status on namespace and name informed.
+function rollout_status() {
+    local namespace="${1}"
+    local deployment="${2}"
+
+    if ! kubectl --namespace="${namespace}" --timeout=${DEPLOYMENT_TIMEOUT} \
+        rollout status deployment "${deployment}"; then
+        fail "'${namespace}/${deployment}' is not deployed as expected!"
+    fi
+}
+
+# inspect the path after the informed executable name.
+function probe_bin_on_path() {
+    local name="${1}"
+
+    if ! type -a ${name} &>/dev/null; then
+        fail "Can't find '${name}' on 'PATH=${PATH}'"
+    fi
+}
+
+# get the artifact url for the specific version (release) or latest.
+function get_release_artifact_url() {
+    local _org_repo="${1}"
+    local _version="${2}"
+
+    local _url="https://api.github.com/repos/${_org_repo}/releases"
+    if [[ "${_version}" == "latest" ]]; then
+        echo $(
+            curl -s ${_url}/latest |
+                jq -r '.assets[].browser_download_url' |
+                egrep -i 'release.yaml' |
+                head -n 1
+        )
+    else
+        echo $(
+            curl -s ${_url} |
+                jq -r ".[] | select(.tag_name == \"${_version}\") | .assets[].browser_download_url" |
+                egrep -i 'release.yaml' |
+                head -n 1
+        )
+    fi
+}

--- a/setup-tektoncd/deploy.sh
+++ b/setup-tektoncd/deploy.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Setting up a new KinD instance, and right after, rolling out the Container Registry and Tekton
+# Pipelines. The instnace will be available as the current kubeconfig context.
+#
+
+shopt -s inherit_errexit
+set -xeu -o pipefail
+
+kind delete cluster
+kind create cluster
+kind export kubeconfig
+
+source .env
+
+./install-registry.sh
+./install-tekton.sh

--- a/setup-tektoncd/inputs.sh
+++ b/setup-tektoncd/inputs.sh
@@ -1,0 +1,23 @@
+#
+# GitHub Action Inputs
+#
+
+# action inputs represented as environment variables
+readonly INPUT_PIPELINE_VERSION="${INPUT_PIPELINE_VERSION:-}"
+export INPUT_PIPELINE_VERSION
+readonly INPUT_CLI_VERSION="${INPUT_CLI_VERSION:-}"
+export INPUT_CLI_VERSION
+readonly INPUT_FEATURE_FLAGS="${INPUT_FEATURE_FLAGS:-}"
+export INPUT_FEATURE_FLAGS
+
+for v in INPUT_PIPELINE_VERSION INPUT_FEATURE_FLAGS INPUT_CLI_VERSION; do
+	[[ -z "${!v}" ]] &&
+		fail "'${v}' environment variable is not set!"
+done
+
+# path to the current workspace
+readonly GITHUB_WORKSPACE="${GITHUB_WORKSPACE:-.}"
+export GITHUB_WORKSPACE
+# name of the organization and repository, joined by slash
+readonly GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-}"
+export GITHUB_REPOSITORY

--- a/setup-tektoncd/install-pipeline.sh
+++ b/setup-tektoncd/install-pipeline.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Installs Tekton Pipelines using the first argument as target version.
+#
+
+shopt -s inherit_errexit
+set -eu -o pipefail
+
+source "$(dirname ${BASH_SOURCE[0]})/common.sh"
+source "$(dirname ${BASH_SOURCE[0]})/inputs.sh"
+
+function _kubectl() {
+	set -x
+	eval "kubectl ${*}"
+	set +x
+}
+
+readonly url=$(get_release_artifact_url "tektoncd/pipeline" "${INPUT_PIPELINE_VERSION}")
+
+phase "Deploying Tekton Pipelines '${INPUT_PIPELINE_VERSION}'"
+_kubectl apply -f ${url}
+
+phase "Waiting for Tekton components"
+
+rollout_status "${TEKTON_NAMESPACE}" "tekton-pipelines-controller"
+rollout_status "${TEKTON_NAMESPACE}" "tekton-pipelines-webhook"
+
+# graceful wait to give some more time for the tekton componets stabilize
+sleep 30
+
+phase "Setting up the feature-flag(s): '${INPUT_FEATURE_FLAGS}"
+if [[ -n "${INPUT_FEATURE_FLAGS}" && "${INPUT_FEATURE_FLAGS}" != "{}" ]]; then
+	_kubectl patch configmap/feature-flags \
+		--namespace="${TEKTON_NAMESPACE}" \
+		--type=merge \
+		--patch="'{ \"data\": ${INPUT_FEATURE_FLAGS} }'"
+
+	# after patching the feature flags, making sure the rollout is not progressing again
+	rollout_status "${TEKTON_NAMESPACE}" "tekton-pipelines-controller"
+	rollout_status "${TEKTON_NAMESPACE}" "tekton-pipelines-webhook"
+	rollout_status "${TEKTON_NAMESPACE}" "tekton-events-controller"
+fi

--- a/setup-tektoncd/install-registry.sh
+++ b/setup-tektoncd/install-registry.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Deploys a Container Registry instance, waits for the deployment reach running status.
+#
+
+shopt -s inherit_errexit
+set -eu -o pipefail
+
+source "$(dirname ${BASH_SOURCE[0]})/common.sh"
+
+phase "Deploying a Container Registry on '${REGISTRY_NAMESPACE}' namespace"
+
+cat <<EOS |kubectl apply -o yaml -f -
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${REGISTRY_NAMESPACE}
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: registry
+  namespace: ${REGISTRY_NAMESPACE}
+  name: registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: registry
+  template:
+    metadata:
+      labels:
+        app: registry
+    spec:
+      containers:
+        - image: registry:2
+          name: registry
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: REGISTRY_STORAGE_DELETE_ENABLED
+              value: "true"
+          ports:
+            - containerPort: 5000
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128M
+            limits:
+              cpu: 100m
+              memory: 128M
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: registry
+  namespace: ${REGISTRY_NAMESPACE}
+  name: registry
+spec:
+  type: NodePort
+  ports:
+    - port: 32222
+      nodePort: 32222
+      protocol: TCP
+      targetPort: 5000
+  selector:
+    app: registry
+EOS
+
+
+phase "Waiting for Registry rollout"
+rollout_status "${REGISTRY_NAMESPACE}" "registry"

--- a/setup-tektoncd/patch-etc-hosts.sh
+++ b/setup-tektoncd/patch-etc-hosts.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Patches /etc/hosts to include the registry FQDN resolving to localhost.
+#
+
+set -eu -o pipefail
+
+source "$(dirname ${BASH_SOURCE[0]})/common.sh"
+source "$(dirname ${BASH_SOURCE[0]})/inputs.sh"
+
+readonly etc_hosts="/etc/hosts"
+readonly hosts_entry="127.0.0.1 ${REGISTRY_HOSTNAME}"
+
+phase "Patching '${etc_hosts}' with '${hosts_entry}' entry"
+if ! grep -q "${hosts_entry}" ${etc_hosts} ; then
+	echo "${hosts_entry}" >>${etc_hosts}
+fi

--- a/setup-tektoncd/probe.sh
+++ b/setup-tektoncd/probe.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Inspect the instance to make sure the dependencies needed are in place.
+#
+
+shopt -s inherit_errexit
+set -eu -o pipefail
+
+source "$(dirname ${BASH_SOURCE[0]})/common.sh"
+
+probe_bin_on_path "curl"
+probe_bin_on_path "kubectl"
+
+if ! kubectl version &> k-version.out; then
+    cat k-version.out
+    fail "'kubectl version' fails to report server version"
+fi


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Import setup-tektoncd from openshift-pipelines. This adds the content of `openshift-pipelines/setup-tektoncd` in a folder called `setup-tektoncd`.
It also adapts some files to reflect the new org (and the fact the there is no release, hence no version yet)


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](CONTRIBUTING.md) for more details._

# Release Notes

```release-note
NONE
```
