### PR TITLE
fix: use local copy of setup-tektoncd-cli to avoid self-reference

### DIFF
--- a/.github/workflows/use-setup-tektoncd-action.yaml
+++ b/.github/workflows/use-setup-tektoncd-action.yaml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # preparing the Kubernetes cluster# (KinD) and installing kubectl
-      - uses: helm/kind-action@v1.10.0
+      - uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
         with:
           cluster_name: kind
           wait: 120s
       # checking out the project code on the current workspace
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       # self loading the action.yaml definitions, making possible to run the action defined on this
       # project directly
       - uses: ./setup-tektoncd/

--- a/.github/workflows/use-setup-tektoncd-cli-action.yaml
+++ b/.github/workflows/use-setup-tektoncd-cli-action.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # checking out the project code on the current workspace
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       # self loading the action.yaml definitions, making possible to run the action defined on this
       # project directly

--- a/setup-tektoncd/action.yaml
+++ b/setup-tektoncd/action.yaml
@@ -68,7 +68,13 @@ runs:
         INPUT_CLI_VERSION: ${{ inputs.cli_version }}
       run: sudo --preserve-env ${{ github.action_path }}/patch-etc-hosts.sh
 
+    # copy setup-tektoncd-cli to a location 
+    - shell: bash
+      run: |
+        mkdir -p .github/_actions
+        cp -r ${{ github.action_path }}/../setup-tektoncd-cli .github/_actions/
+
     # installs the pre-compiled Tekton CLI
-    - uses: tektoncd/actions/setup-tektoncd-cli@main
+    - uses: ./.github/_actions/setup-tektoncd-cli
       with:
         version: ${{ inputs.cli_version }}


### PR DESCRIPTION
The setup-tektoncd action was referencing tektoncd/actions/setup-tektoncd-cli@main, which violates the security policy requiring all actions to be pinned to full-length commit SHAs. This caused nightly workflows to fail.

This fix copies the setup-tektoncd-cli action to .github/_actions/ at runtime and references it using a relative path, eliminating the need for the external reference