### PR TITLE
Add checksum verification for downloaded artifacts

### DIFF
--- a/setup-tektoncd-cli/common.sh
+++ b/setup-tektoncd-cli/common.sh
@@ -22,6 +22,63 @@ function probe_bin_on_path() {
     fi
 }
 
+# get the checksums.txt url for the specific version (release) or latest.
+function get_checksums_url() {
+    local _org_repo="${1}"
+    local _version="${2}"
+
+    local _url="https://api.github.com/repos/${_org_repo}/releases"
+    if [[ "${_version}" == "latest" ]]; then
+        echo $(
+            curl -s ${_url}/latest |
+                jq -r '.assets[].browser_download_url' |
+                grep -i 'checksums.txt' |
+                head -n 1
+        )
+    else
+        echo $(
+            curl -s ${_url} |
+                jq -r ".[] | select(.tag_name == \"${_version}\") | .assets[].browser_download_url" |
+                grep -i 'checksums.txt' |
+                head -n 1
+        )
+    fi
+}
+
+# verify the sha256 checksum of a downloaded file against checksums.txt from the release.
+function verify_checksum() {
+    local _file="${1}"
+    local _checksums_url="${2}"
+
+    if [[ -z "${_checksums_url}" ]]; then
+        fail "No checksums URL available for verification"
+    fi
+
+    local _filename="$(basename ${_file})"
+    local _tmp_checksums="/tmp/checksums.txt"
+
+    phase "Downloading checksums from '${_checksums_url}'"
+    curl -sL "${_checksums_url}" > "${_tmp_checksums}"
+
+    local _expected
+    _expected=$(grep "${_filename}" "${_tmp_checksums}" | awk '{print $1}')
+    if [[ -z "${_expected}" ]]; then
+        rm -f "${_tmp_checksums}"
+        fail "No checksum found for '${_filename}' in checksums.txt"
+    fi
+
+    local _actual
+    _actual=$(sha256sum "${_file}" | awk '{print $1}')
+
+    rm -f "${_tmp_checksums}"
+
+    if [[ "${_expected}" != "${_actual}" ]]; then
+        fail "Checksum mismatch for '${_filename}': expected=${_expected} actual=${_actual}"
+    fi
+
+    phase "Checksum verified for '${_filename}': ${_actual}"
+}
+
 # get the artifact url for the specific version (release) or latest.
 function get_release_artifact_url() {
     local _org_repo="${1}"
@@ -59,6 +116,11 @@ function download_and_install() {
 
     phase "Downloading '${_url}' to '${_tmp_tarball}'"
     curl -sL ${_url} >${_tmp_tarball}
+
+    # verify checksum if a checksums URL is provided
+    if [[ -n "${3:-}" ]]; then
+        verify_checksum "${_tmp_tarball}" "${3}"
+    fi
 
     phase "Installing '${_bin_name}' on prefix '${_prefix}'"
     tar -C ${_prefix} -zxvpf ${_tmp_tarball} ${_bin_name}

--- a/setup-tektoncd-cli/install-cli.sh
+++ b/setup-tektoncd-cli/install-cli.sh
@@ -22,5 +22,11 @@ readonly url=$(get_release_artifact_url "tektoncd/cli" ${INPUT_VERSION})
 [[ -z "${url}" ]] &&
     fail "Unable to acrquire the release artifact download URL"
 
+phase "Searching for checksums"
+readonly checksums_url=$(get_checksums_url "tektoncd/cli" ${INPUT_VERSION})
+
+[[ -z "${checksums_url}" ]] &&
+    fail "Unable to acquire the checksums URL for verification"
+
 phase "Download URL '${url}'"
-download_and_install ${url} "tkn"
+download_and_install ${url} "tkn" ${checksums_url}

--- a/setup-tektoncd/install-pipeline.sh
+++ b/setup-tektoncd/install-pipeline.sh
@@ -18,7 +18,14 @@ function _kubectl() {
 readonly url=$(get_release_artifact_url "tektoncd/pipeline" "${INPUT_PIPELINE_VERSION}")
 
 phase "Deploying Tekton Pipelines '${INPUT_PIPELINE_VERSION}'"
-_kubectl apply -f ${url}
+
+# Pipeline releases don't publish a checksums file, so we download first,
+# log the SHA256 for audit trail, then apply.
+readonly tmp_release="/tmp/tekton-pipeline-release.yaml"
+curl -sL "${url}" > "${tmp_release}"
+phase "SHA256 of release.yaml: $(sha256sum "${tmp_release}" | awk '{print $1}')"
+_kubectl apply -f "${tmp_release}"
+rm -f "${tmp_release}"
 
 phase "Waiting for Tekton components"
 

--- a/setup-tektoncd/install-pipeline.sh
+++ b/setup-tektoncd/install-pipeline.sh
@@ -19,11 +19,38 @@ readonly url=$(get_release_artifact_url "tektoncd/pipeline" "${INPUT_PIPELINE_VE
 
 phase "Deploying Tekton Pipelines '${INPUT_PIPELINE_VERSION}'"
 
-# Pipeline releases don't publish a checksums file, so we download first,
-# log the SHA256 for audit trail, then apply.
+# Download release.yaml and verify its SHA256 against GitHub's release digest
 readonly tmp_release="/tmp/tekton-pipeline-release.yaml"
 curl -sL "${url}" > "${tmp_release}"
-phase "SHA256 of release.yaml: $(sha256sum "${tmp_release}" | awk '{print $1}')"
+
+readonly actual_sha256=$(sha256sum "${tmp_release}" | awk '{print $1}')
+phase "SHA256 of release.yaml: ${actual_sha256}"
+
+# Fetch expected digest from GitHub release API
+readonly release_tag=$(
+    if [[ "${INPUT_PIPELINE_VERSION}" == "latest" ]]; then
+        curl -s "https://api.github.com/repos/tektoncd/pipeline/releases/latest" | jq -r '.tag_name'
+    else
+        echo "${INPUT_PIPELINE_VERSION}"
+    fi
+)
+if command -v gh &>/dev/null; then
+    expected_digest=$(gh release view "${release_tag}" --repo tektoncd/pipeline \
+        --json assets --jq '.assets[] | select(.name == "release.yaml") | .digest' 2>/dev/null || true)
+    if [[ -n "${expected_digest}" ]]; then
+        expected_sha256="${expected_digest#sha256:}"
+        if [[ "${actual_sha256}" == "${expected_sha256}" ]]; then
+            phase "Checksum verification passed"
+        else
+            fail "Checksum mismatch! Expected ${expected_sha256}, got ${actual_sha256}"
+        fi
+    else
+        phase "WARNING: Could not fetch expected digest, skipping verification"
+    fi
+else
+    phase "WARNING: gh CLI not available, skipping checksum verification"
+fi
+
 _kubectl apply -f "${tmp_release}"
 rm -f "${tmp_release}"
 


### PR DESCRIPTION
Fixes #11

- Verify SHA256 checksums for tkn CLI downloads against the release `checksums.txt`
- Verify SHA256 of pipeline `release.yaml` against GitHub's built-in release asset digests (via `gh release view`)
- Fails the install if checksum mismatch is detected; gracefully skips if `gh` CLI is unavailable

Previously we only logged checksums for audit. Now that GitHub [exposes SHA256 digests for release assets](https://github.blog/changelog/2025-06-03-releases-now-expose-digests-for-release-assets/), we can do real verification (h/t @AlanGreene in tektoncd/pipeline#9959).