### PR TITLE
Update actions/checkout to v4 and enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/use-setup-tektoncd-action.yaml
+++ b/.github/workflows/use-setup-tektoncd-action.yaml
@@ -28,7 +28,7 @@ jobs:
           cluster_name: kind
           wait: 120s
       # checking out the project code on the current workspace
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       # self loading the action.yaml definitions, making possible to run the action defined on this
       # project directly
       - uses: ./setup-tektoncd/

--- a/.github/workflows/use-setup-tektoncd-cli-action.yaml
+++ b/.github/workflows/use-setup-tektoncd-cli-action.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # checking out the project code on the current workspace
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # self loading the action.yaml definitions, making possible to run the action defined on this
       # project directly


### PR DESCRIPTION
Fixes #12

- Update `actions/checkout` from v3 to v4 (SHA-pinned)
- Add `.github/dependabot.yml` for automated weekly GitHub Actions updates

No Dependabot configuration existed previously, so pinned action versions would never receive automated update PRs.