### PR TITLE
Handle GitHub API errors and add github_token input

### DIFF
--- a/setup-tektoncd-cli/action.yaml
+++ b/setup-tektoncd-cli/action.yaml
@@ -11,6 +11,12 @@ inputs:
       Tekton CLI release version
     default: latest
     required: false
+  github_token:
+    description: |
+      GitHub token for API requests. Prevents rate-limiting when fetching release
+      information. Defaults to the built-in GITHUB_TOKEN.
+    required: false
+    default: ${{ github.token }}
 runs:
   using: composite
   steps:
@@ -22,4 +28,5 @@ runs:
     - shell: bash
       env:
         INPUT_VERSION: ${{ inputs.version }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
       run: sudo --preserve-env ${{ github.action_path }}/install-cli.sh

--- a/setup-tektoncd-cli/common.sh
+++ b/setup-tektoncd-cli/common.sh
@@ -22,27 +22,61 @@ function probe_bin_on_path() {
     fi
 }
 
+# helper to build curl auth headers when GITHUB_TOKEN is available.
+function _gh_curl() {
+    local _curl_args=(-s -f)
+    if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+        _curl_args+=(-H "Authorization: token ${GITHUB_TOKEN}")
+    fi
+    local _response
+    if ! _response=$(curl "${_curl_args[@]}" "$@" 2>&1); then
+        fail "GitHub API request failed for '$*'. Response: ${_response}. If this is a rate-limit error, set the 'github_token' input."
+    fi
+    echo "${_response}"
+}
+
 # get the artifact url for the specific version (release) or latest.
 function get_release_artifact_url() {
     local _org_repo="${1}"
     local _version="${2}"
 
     local _url="https://api.github.com/repos/${_org_repo}/releases"
+    local _response
     if [[ "${_version}" == "latest" ]]; then
-        echo $(
-            curl -s ${_url}/latest |
+        _response=$(_gh_curl "${_url}/latest")
+    else
+        _response=$(_gh_curl "${_url}")
+    fi
+
+    # check for API error messages
+    if echo "${_response}" | jq -e '.message' &>/dev/null; then
+        local _msg
+        _msg=$(echo "${_response}" | jq -r '.message')
+        fail "GitHub API error: ${_msg}. If this is a rate-limit error, set the 'github_token' input."
+    fi
+
+    local _artifact_url
+    if [[ "${_version}" == "latest" ]]; then
+        _artifact_url=$(
+            echo "${_response}" |
                 jq -r '.assets[].browser_download_url' |
                 egrep -i 'linux_(x86_64|amd64)' |
                 head -n 1
         )
     else
-        echo $(
-            curl -s ${_url} |
+        _artifact_url=$(
+            echo "${_response}" |
                 jq -r ".[] | select(.tag_name == \"${_version}\") | .assets[].browser_download_url" |
                 egrep -i 'linux_(x86_64|amd64)' |
                 head -n 1
         )
     fi
+
+    if [[ -z "${_artifact_url}" ]]; then
+        fail "Could not find release artifact for ${_org_repo} version '${_version}'"
+    fi
+
+    echo "${_artifact_url}"
 }
 
 # given the download url and excutable name, download and extract the executable from the artifact

--- a/setup-tektoncd-cli/common.sh
+++ b/setup-tektoncd-cli/common.sh
@@ -22,9 +22,24 @@ function probe_bin_on_path() {
     fi
 }
 
-# helper to build curl auth headers when GITHUB_TOKEN is available.
+# compute the sha256 checksum of a file, using sha256sum or shasum -a 256.
+# returns non-zero if no SHA256 tool is available.
+function _sha256() {
+    local _file="${1}"
+    if command -v sha256sum &>/dev/null; then
+        sha256sum "${_file}" | awk '{print $1}'
+    elif command -v shasum &>/dev/null; then
+        shasum -a 256 "${_file}" | awk '{print $1}'
+    else
+        return 1
+    fi
+}
+
+# helper to perform an authenticated GitHub API request when GITHUB_TOKEN is
+# available. Captures the response body and HTTP status so API error messages
+# (e.g. rate-limit details) can be surfaced to the caller.
 function _gh_curl() {
-    local _curl_args=(-s -f)
+    local _curl_args=(-sSL -w '\n%{http_code}')
     if [[ -n "${GITHUB_TOKEN:-}" ]]; then
         _curl_args+=(-H "Authorization: token ${GITHUB_TOKEN}")
     fi
@@ -32,7 +47,99 @@ function _gh_curl() {
     if ! _response=$(curl "${_curl_args[@]}" "$@" 2>&1); then
         fail "GitHub API request failed for '$*'. Response: ${_response}. If this is a rate-limit error, set the 'github_token' input."
     fi
-    echo "${_response}"
+    local _http_code="${_response##*$'\n'}"
+    local _body="${_response%$'\n'*}"
+    if [[ "${_http_code}" -lt 200 || "${_http_code}" -ge 300 ]]; then
+        local _msg
+        _msg=$(echo "${_body}" | jq -r '.message // empty' 2>/dev/null)
+        [[ -z "${_msg}" ]] && _msg="HTTP ${_http_code}"
+        fail "GitHub API error (${_http_code}): ${_msg}. If this is a rate-limit error, set the 'github_token' input."
+    fi
+    echo "${_body}"
+}
+
+# get the checksums.txt url for the specific version (release) or latest.
+function get_checksums_url() {
+    local _org_repo="${1}"
+    local _version="${2}"
+
+    local _url="https://api.github.com/repos/${_org_repo}/releases"
+    local _response
+    if [[ "${_version}" == "latest" ]]; then
+        _response=$(_gh_curl "${_url}/latest")
+    else
+        _response=$(_gh_curl "${_url}")
+    fi
+
+    local _checksums_url
+    if [[ "${_version}" == "latest" ]]; then
+        _checksums_url=$(
+            echo "${_response}" |
+                jq -r '.assets[].browser_download_url' |
+                grep -i 'checksums.txt' |
+                head -n 1
+        )
+    else
+        _checksums_url=$(
+            echo "${_response}" |
+                jq -r ".[] | select(.tag_name == \"${_version}\") | .assets[].browser_download_url" |
+                grep -i 'checksums.txt' |
+                head -n 1
+        )
+    fi
+
+    if [[ -z "${_checksums_url}" ]]; then
+        fail "Could not find checksums.txt for ${_org_repo} version '${_version}'"
+    fi
+
+    echo "${_checksums_url}"
+}
+
+# verify the sha256 checksum of a downloaded file against checksums.txt from the release.
+function verify_checksum() {
+    local _file="${1}"
+    local _checksums_url="${2}"
+
+    if [[ -z "${_checksums_url}" ]]; then
+        fail "No checksums URL available for verification"
+    fi
+
+    local _actual
+    if ! _actual=$(_sha256 "${_file}"); then
+        phase "WARNING: no SHA256 tool (sha256sum/shasum) available, skipping checksum verification"
+        return 0
+    fi
+
+    local _filename
+    _filename="$(basename "${_file}")"
+    local _tmp_checksums
+    _tmp_checksums="$(mktemp)"
+    # shellcheck disable=SC2064
+    trap "rm -f '${_tmp_checksums}'" RETURN
+
+    phase "Downloading checksums from '${_checksums_url}'"
+    if ! curl -fsSL "${_checksums_url}" > "${_tmp_checksums}"; then
+        fail "Failed to download checksums from '${_checksums_url}'"
+    fi
+
+    # match the filename field exactly (second column) to avoid substring
+    # matches; checksums.txt entries look like '<hash>  <file>' or '<hash> *<file>'.
+    local _expected
+    _expected=$(awk -v f="${_filename}" '$2 == f || $2 == "*"f {print $1}' "${_tmp_checksums}")
+
+    local _count
+    _count=$(printf '%s\n' "${_expected}" | grep -c . || true)
+    if [[ "${_count}" -eq 0 ]]; then
+        fail "No checksum found for '${_filename}' in checksums.txt"
+    elif [[ "${_count}" -gt 1 ]]; then
+        fail "Multiple checksum entries found for '${_filename}' in checksums.txt"
+    fi
+
+    if [[ "${_expected}" != "${_actual}" ]]; then
+        fail "Checksum mismatch for '${_filename}': expected=${_expected} actual=${_actual}"
+    fi
+
+    phase "Checksum verified for '${_filename}': ${_actual}"
 }
 
 # get the artifact url for the specific version (release) or latest.
@@ -46,13 +153,6 @@ function get_release_artifact_url() {
         _response=$(_gh_curl "${_url}/latest")
     else
         _response=$(_gh_curl "${_url}")
-    fi
-
-    # check for API error messages
-    if echo "${_response}" | jq -e '.message' &>/dev/null; then
-        local _msg
-        _msg=$(echo "${_response}" | jq -r '.message')
-        fail "GitHub API error: ${_msg}. If this is a rate-limit error, set the 'github_token' input."
     fi
 
     local _artifact_url
@@ -84,17 +184,27 @@ function get_release_artifact_url() {
 function download_and_install() {
     local _url="${1}"
     local _bin_name="${2}"
+    local _checksums_url="${3:-}"
 
-    local _tarball="$(basename ${_url})"
-    local _tmp_tarball="/tmp/${_tarball}"
     local _prefix="/usr/local/bin"
-
-    [[ -f "${_tmp_tarball}" ]] && rm -f "${_tmp_tarball}"
+    local _tarball
+    _tarball="$(basename "${_url}")"
+    local _tmp_dir
+    _tmp_dir="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '${_tmp_dir}'" RETURN
+    local _tmp_tarball="${_tmp_dir}/${_tarball}"
 
     phase "Downloading '${_url}' to '${_tmp_tarball}'"
-    curl -sL ${_url} >${_tmp_tarball}
+    if ! curl -fsSL "${_url}" > "${_tmp_tarball}"; then
+        fail "Failed to download '${_url}'"
+    fi
+
+    # verify checksum if a checksums URL is provided
+    if [[ -n "${_checksums_url}" ]]; then
+        verify_checksum "${_tmp_tarball}" "${_checksums_url}"
+    fi
 
     phase "Installing '${_bin_name}' on prefix '${_prefix}'"
-    tar -C ${_prefix} -zxvpf ${_tmp_tarball} ${_bin_name}
-    rm -fv "${_tmp_tarball}"
+    tar -C "${_prefix}" -zxvpf "${_tmp_tarball}" "${_bin_name}"
 }

--- a/setup-tektoncd-cli/common.sh
+++ b/setup-tektoncd-cli/common.sh
@@ -43,9 +43,13 @@ function _gh_curl() {
     if [[ -n "${GITHUB_TOKEN:-}" ]]; then
         _curl_args+=(-H "Authorization: token ${GITHUB_TOKEN}")
     fi
+    local _stderr
+    _stderr="$(mktemp)"
+    # shellcheck disable=SC2064
+    trap "rm -f '${_stderr}'" RETURN
     local _response
-    if ! _response=$(curl "${_curl_args[@]}" "$@" 2>&1); then
-        fail "GitHub API request failed for '$*'. Response: ${_response}. If this is a rate-limit error, set the 'github_token' input."
+    if ! _response=$(curl "${_curl_args[@]}" "$@" 2>"${_stderr}"); then
+        fail "GitHub API request failed for '$*'. Response: $(cat "${_stderr}"). If this is a rate-limit error, set the 'github_token' input."
     fi
     local _http_code="${_response##*$'\n'}"
     local _body="${_response%$'\n'*}"

--- a/setup-tektoncd-cli/install-cli.sh
+++ b/setup-tektoncd-cli/install-cli.sh
@@ -17,16 +17,16 @@ readonly INPUT_VERSION="${INPUT_VERSION:-}"
 
 phase "Searching for '${INPUT_VERSION}' release artifact"
 
-readonly url=$(get_release_artifact_url "tektoncd/cli" ${INPUT_VERSION})
+readonly url=$(get_release_artifact_url "tektoncd/cli" "${INPUT_VERSION}")
 
 [[ -z "${url}" ]] &&
     fail "Unable to acrquire the release artifact download URL"
 
 phase "Searching for checksums"
-readonly checksums_url=$(get_checksums_url "tektoncd/cli" ${INPUT_VERSION})
+readonly checksums_url=$(get_checksums_url "tektoncd/cli" "${INPUT_VERSION}")
 
 [[ -z "${checksums_url}" ]] &&
     fail "Unable to acquire the checksums URL for verification"
 
 phase "Download URL '${url}'"
-download_and_install ${url} "tkn" ${checksums_url}
+download_and_install "${url}" "tkn" "${checksums_url}"

--- a/setup-tektoncd-cli/install-cli.sh
+++ b/setup-tektoncd-cli/install-cli.sh
@@ -22,5 +22,11 @@ readonly url=$(get_release_artifact_url "tektoncd/cli" ${INPUT_VERSION})
 [[ -z "${url}" ]] &&
     fail "Unable to acrquire the release artifact download URL"
 
+phase "Searching for checksums"
+readonly checksums_url=$(get_checksums_url "tektoncd/cli" ${INPUT_VERSION})
+
+[[ -z "${checksums_url}" ]] &&
+    fail "Unable to acquire the checksums URL for verification"
+
 phase "Download URL '${url}'"
-download_and_install ${url} "tkn"
+download_and_install ${url} "tkn" ${checksums_url}

--- a/setup-tektoncd/action.yaml
+++ b/setup-tektoncd/action.yaml
@@ -33,6 +33,12 @@ inputs:
       Patch "/etc/hosts" to alias the Container Registry hostname to "127.0.0.1"
     required: false
     default: "true"
+  github_token:
+    description: |
+      GitHub token used for checksum verification against GitHub release digests
+      and for CLI release artifact discovery. Defaults to the built-in GITHUB_TOKEN.
+    required: false
+    default: ${{ github.token }}
 runs:
   using: composite
   steps:
@@ -57,6 +63,7 @@ runs:
         INPUT_PIPELINE_VERSION: ${{ inputs.pipeline_version }}
         INPUT_FEATURE_FLAGS: ${{ inputs.feature_flags }}
         INPUT_CLI_VERSION: ${{ inputs.cli_version }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
       run: ${{ github.action_path }}/install-pipeline.sh
 
     # patches the /etc/hosts to include the container registry hostname resolving to 127.0.0.1
@@ -78,3 +85,4 @@ runs:
     - uses: ./.github/_actions/setup-tektoncd-cli
       with:
         version: ${{ inputs.cli_version }}
+        github_token: ${{ inputs.github_token }}

--- a/setup-tektoncd/common.sh
+++ b/setup-tektoncd/common.sh
@@ -49,25 +49,67 @@ function probe_bin_on_path() {
     fi
 }
 
-# get the artifact url for the specific version (release) or latest.
+# get the release artifact URL from infra.tekton.dev for the given component and version.
 function get_release_artifact_url() {
-    local _org_repo="${1}"
+    local _component="${1}"
     local _version="${2}"
 
-    local _url="https://api.github.com/repos/${_org_repo}/releases"
+    local _base="https://infra.tekton.dev/tekton-releases/${_component}"
+    local _url
     if [[ "${_version}" == "latest" ]]; then
-        echo $(
-            curl -s ${_url}/latest |
-                jq -r '.assets[].browser_download_url' |
-                egrep -i 'release.yaml' |
-                head -n 1
-        )
+        _url="${_base}/latest/release.yaml"
     else
-        echo $(
-            curl -s ${_url}/tags/${_version} |
-                jq -r ".assets[].browser_download_url" |
-                egrep -i 'release.yaml' |
-                head -n 1
-        )
+        _url="${_base}/previous/${_version}/release.yaml"
+    fi
+
+    # verify the URL is reachable
+    if ! curl -sIL -o /dev/null -w '%{http_code}' "${_url}" | grep -q '^2'; then
+        fail "Release artifact not found at ${_url}"
+    fi
+
+    echo "${_url}"
+}
+
+# verify the SHA256 checksum of a downloaded file against GitHub's release digest.
+# requires gh CLI and GITHUB_TOKEN for authenticated requests.
+function verify_checksum() {
+    local _file="${1}"
+    local _repo="${2}"
+    local _version="${3}"
+    local _asset_name="${4}"
+
+    local _actual_sha256
+    _actual_sha256=$(sha256sum "${_file}" | awk '{print $1}')
+    phase "SHA256 of ${_asset_name}: ${_actual_sha256}"
+
+    if ! command -v gh &>/dev/null; then
+        phase "WARNING: gh CLI not available, skipping checksum verification"
+        return 0
+    fi
+
+    # resolve "latest" to actual tag
+    local _tag="${_version}"
+    if [[ "${_version}" == "latest" ]]; then
+        _tag=$(gh release view --repo "${_repo}" --json tagName --jq '.tagName' 2>/dev/null || true)
+        if [[ -z "${_tag}" ]]; then
+            phase "WARNING: Could not resolve latest version, skipping checksum verification"
+            return 0
+        fi
+    fi
+
+    local _expected_digest
+    _expected_digest=$(gh release view "${_tag}" --repo "${_repo}" \
+        --json assets --jq ".assets[] | select(.name == \"${_asset_name}\") | .digest" 2>/dev/null || true)
+
+    if [[ -z "${_expected_digest}" ]]; then
+        phase "WARNING: Could not fetch expected digest from GitHub, skipping verification"
+        return 0
+    fi
+
+    local _expected_sha256="${_expected_digest#sha256:}"
+    if [[ "${_actual_sha256}" == "${_expected_sha256}" ]]; then
+        phase "Checksum verification passed (cross-verified against GitHub release digest)"
+    else
+        fail "Checksum mismatch! Expected ${_expected_sha256} (from GitHub), got ${_actual_sha256} (from infra.tekton.dev)"
     fi
 }

--- a/setup-tektoncd/common.sh
+++ b/setup-tektoncd/common.sh
@@ -70,6 +70,19 @@ function get_release_artifact_url() {
     echo "${_url}"
 }
 
+# compute the sha256 checksum of a file, using sha256sum or shasum -a 256.
+# returns non-zero if no SHA256 tool is available.
+function _sha256() {
+    local _file="${1}"
+    if command -v sha256sum &>/dev/null; then
+        sha256sum "${_file}" | awk '{print $1}'
+    elif command -v shasum &>/dev/null; then
+        shasum -a 256 "${_file}" | awk '{print $1}'
+    else
+        return 1
+    fi
+}
+
 # verify the SHA256 checksum of a downloaded file against GitHub's release digest.
 # requires gh CLI and GITHUB_TOKEN for authenticated requests.
 function verify_checksum() {
@@ -79,7 +92,10 @@ function verify_checksum() {
     local _asset_name="${4}"
 
     local _actual_sha256
-    _actual_sha256=$(sha256sum "${_file}" | awk '{print $1}')
+    if ! _actual_sha256=$(_sha256 "${_file}"); then
+        phase "WARNING: no SHA256 tool (sha256sum/shasum) available, skipping checksum verification"
+        return 0
+    fi
     phase "SHA256 of ${_asset_name}: ${_actual_sha256}"
 
     if ! command -v gh &>/dev/null; then
@@ -92,8 +108,7 @@ function verify_checksum() {
     if [[ "${_version}" == "latest" ]]; then
         _tag=$(gh release view --repo "${_repo}" --json tagName --jq '.tagName' 2>/dev/null || true)
         if [[ -z "${_tag}" ]]; then
-            phase "WARNING: Could not resolve latest version, skipping checksum verification"
-            return 0
+            fail "gh is available but could not resolve the latest release tag for ${_repo}"
         fi
     fi
 
@@ -102,8 +117,7 @@ function verify_checksum() {
         --json assets --jq ".assets[] | select(.name == \"${_asset_name}\") | .digest" 2>/dev/null || true)
 
     if [[ -z "${_expected_digest}" ]]; then
-        phase "WARNING: Could not fetch expected digest from GitHub, skipping verification"
-        return 0
+        fail "gh is available but could not fetch the expected digest for '${_asset_name}' from ${_repo} ${_tag}"
     fi
 
     local _expected_sha256="${_expected_digest#sha256:}"

--- a/setup-tektoncd/install-pipeline.sh
+++ b/setup-tektoncd/install-pipeline.sh
@@ -20,11 +20,13 @@ readonly url=$(get_release_artifact_url "pipeline" "${INPUT_PIPELINE_VERSION}")
 phase "Deploying Tekton Pipelines '${INPUT_PIPELINE_VERSION}'"
 
 # Download release.yaml, verify checksum against GitHub's digest, then apply
-readonly tmp_release="/tmp/tekton-pipeline-release.yaml"
-curl -sL "${url}" > "${tmp_release}"
+tmp_release="$(mktemp)"
+trap 'rm -f "${tmp_release}"' EXIT
+if ! curl -fsSL "${url}" > "${tmp_release}"; then
+    fail "Failed to download release manifest from '${url}'"
+fi
 verify_checksum "${tmp_release}" "tektoncd/pipeline" "${INPUT_PIPELINE_VERSION}" "release.yaml"
 _kubectl apply -f "${tmp_release}"
-rm -f "${tmp_release}"
 
 phase "Waiting for Tekton components"
 

--- a/setup-tektoncd/install-pipeline.sh
+++ b/setup-tektoncd/install-pipeline.sh
@@ -15,10 +15,16 @@ function _kubectl() {
 	set +x
 }
 
-readonly url=$(get_release_artifact_url "tektoncd/pipeline" "${INPUT_PIPELINE_VERSION}")
+readonly url=$(get_release_artifact_url "pipeline" "${INPUT_PIPELINE_VERSION}")
 
 phase "Deploying Tekton Pipelines '${INPUT_PIPELINE_VERSION}'"
-_kubectl apply -f ${url}
+
+# Download release.yaml, verify checksum against GitHub's digest, then apply
+readonly tmp_release="/tmp/tekton-pipeline-release.yaml"
+curl -sL "${url}" > "${tmp_release}"
+verify_checksum "${tmp_release}" "tektoncd/pipeline" "${INPUT_PIPELINE_VERSION}" "release.yaml"
+_kubectl apply -f "${tmp_release}"
+rm -f "${tmp_release}"
 
 phase "Waiting for Tekton components"
 


### PR DESCRIPTION
Fixes #9

## Problem
When GitHub API returns an error (e.g., rate limiting), the actions fail with a cryptic jq error:
```
jq: error (at <stdin>:1): Cannot iterate over null (null)
```
and then proceed to run `kubectl apply -f` with an empty URL.

Users also have no way to provide a GitHub token to avoid rate limiting.

## Changes

### Pipeline (`setup-tektoncd`)
- **Switch from GitHub API to `infra.tekton.dev`** for downloading release artifacts — eliminates rate-limiting issues entirely since no API calls are needed
- **Cross-source checksum verification**: downloads from `infra.tekton.dev`, verifies SHA256 against GitHub's release digest API (via `gh` CLI)
- Gracefully skips verification if `gh` CLI is unavailable

### CLI (`setup-tektoncd-cli`)
- Add proper error handling for GitHub API responses with clear error messages instead of cryptic jq failures
- Add `_gh_curl()` helper with authentication when `GITHUB_TOKEN` is set
- CLI tarballs are not hosted on `infra.tekton.dev`, so GitHub API is still used for discovery

### Both actions
- Add `github_token` input, defaulting to `${{ github.token }}` — works out of the box, no user configuration needed

## Example error (before)
```
jq: error (at <stdin>:1): Cannot iterate over null (null)
```

## Example error (after)
```
ERROR: GitHub API error: API rate limit exceeded for ... set the 'github_token' input.
```

cc @tnevrlka"