### PR TITLE
Update setup-tektoncd to get release by tag name

### DIFF
--- a/setup-tektoncd/common.sh
+++ b/setup-tektoncd/common.sh
@@ -64,8 +64,8 @@ function get_release_artifact_url() {
         )
     else
         echo $(
-            curl -s ${_url} |
-                jq -r ".[] | select(.tag_name == \"${_version}\") | .assets[].browser_download_url" |
+            curl -s ${_url}/tags/${_version} |
+                jq -r ".assets[].browser_download_url" |
                 egrep -i 'release.yaml' |
                 head -n 1
         )


### PR DESCRIPTION
Instead of filtering the list of releases by tag name, use the provided API endpoint to get the specific release by tag name. This avoids issues caused by pagination when the required release is not in the first page of results.

Required to unblock Dashboard and Chains nightly builds which both use the `setup-nightly-infra` action from plumbing, which in turn uses `setup-tektoncd`. These have been broken since June 23rd when a large number of Pipelines patch releases were published, pushing the requested version into the second page of results.

/kind misc
/cc @afrittoli @vdemeester 
fyi @kaushalnavneet